### PR TITLE
allow users to adjust dims of described data

### DIFF
--- a/R/context.R
+++ b/R/context.R
@@ -63,8 +63,9 @@ describe_variable <- function(x, x_name) {
   # to limit the number of tokens taken up by data frames, only print the
   # first few rows and columns of data frames
   if (inherits(x, "data.frame")) {
-    n_row <- min(5, nrow(x))
-    n_col <- min(20, ncol(x))
+    dims <- fetch_gander_dims()
+    n_row <- min(dims[1], nrow(x))
+    n_col <- min(dims[2], ncol(x))
     x <- x[seq_len(n_row), seq_len(n_col), drop = FALSE]
     x_name <- c(
       cli::format_inline("# Just the first {n_row} row{?s} and {n_col} column{?s}:"),

--- a/R/utils.R
+++ b/R/utils.R
@@ -29,6 +29,8 @@ default_gander_style <- function() {
   )
 }
 
+default_gander_dims <- c(5L, 100L)
+
 get_gander_style <- function() {
   res <- getOption(".gander_style")
 

--- a/man/gander_options.Rd
+++ b/man/gander_options.Rd
@@ -5,6 +5,7 @@
 \alias{.gander_fn}
 \alias{.gander_args}
 \alias{.gander_chat}
+\alias{.gander_dims}
 \alias{.gander_style}
 \title{Options used by the gander package}
 \description{
@@ -41,5 +42,28 @@ Paste that code in your
 \code{.Rprofile} via \code{usethis::edit_r_profile()} to always use the same style (or
 even always begin with some base set of knowledge about frameworks you
 work with often) every time you start an R session.
+}
+
+\section{Data context}{
+
+
+By default, gander will show the first 5 rows and 100 columns of every
+relevant data frame, allowing for models to pick up on the names, types, and
+distributions of the variables it may work with while also keeping the number
+of tokens submitted per chat to a minimum. The option \code{.gander_dims} allows
+you to adjust how many rows and columns to supply to gander addin.
+\itemize{
+\item For richer context but increasing token usage, increase the number of rows
+and columns. For example, to supply the first 50 rows and all columns of
+datasets supplied to the model, you could use
+\code{options(.gander_dims = c(50, Inf))}.
+\item To decrease token usage, decrease the number of rows and columns, e.g.
+\code{options(.gander_dims = c(0, 10))} to just show the names and types of the
+first 10 columns. One could make the argument that setting the number of rows
+to 0 is privacy-preserving, but do note that the model may pick up on the
+values of specific cells based on code context alone.
+}
+
+Set that option in your \verb{~/.Rprofile} to always use that setting.
 }
 

--- a/tests/testthat/_snaps/assistant.md
+++ b/tests/testthat/_snaps/assistant.md
@@ -31,6 +31,22 @@
       i Set e.g. `options(.gander_chat = ellmer::chat_claude())` in your '~/.Rprofile' and restart R.
       i See "Choosing a model" in `vignette("gander", package = "gander")` to learn more.
 
+# fetch_gander_dims handles `.gander_dims` appropriately
+
+    Code
+      .res <- fetch_gander_dims()
+    Message
+      ! The option .gander_dims must be a 2-length integer vector, e.g. `c(5L, 100L)`, not a string.
+      i See `?.gander_dims` to learn more.
+
+---
+
+    Code
+      .res <- fetch_gander_dims()
+    Message
+      ! The option .gander_dims must be a 2-length integer vector, e.g. `c(5L, 100L)`, not a number.
+      i See `?.gander_dims` to learn more.
+
 # construct_turn_impl formats message with file extension
 
     Code

--- a/tests/testthat/test-assistant.R
+++ b/tests/testthat/test-assistant.R
@@ -29,6 +29,30 @@ test_that("fetch_gander_chat fails informatively with bad `.gander_chat`", {
   expect_null(.res)
 })
 
+test_that("fetch_gander_dims handles `.gander_dims` appropriately", {
+  # default case, no option set
+  withr::local_options(.gander_dims = NULL)
+  expect_equal(fetch_gander_dims(), default_gander_dims)
+
+  # wrong type
+  withr::local_options(.gander_dims = "boop")
+  expect_snapshot(.res <- fetch_gander_dims())
+  expect_equal(.res, NULL)
+
+  # wrong length
+  withr::local_options(.gander_dims = 5)
+  expect_snapshot(.res <- fetch_gander_dims())
+  expect_equal(.res, NULL)
+
+  # Inf is ok
+  withr::local_options(.gander_dims = c(5, Inf))
+  expect_equal(fetch_gander_dims(), c(5, Inf))
+
+  # both Inf is ok
+  withr::local_options(.gander_dims = c(Inf, Inf))
+  expect_equal(fetch_gander_dims(), c(Inf, Inf))
+})
+
 test_that("construct_system_prompt works", {
   # r files
   context <- list(path = "script.r")


### PR DESCRIPTION
Closes #44.

* Implements `.gander_dims` option to allow users to choose the default numbers of rows and columns they'd like to describe.
* Increases the default number of columns from 20 to 100.
